### PR TITLE
Fixed : When user clicks on get started it redirects to login page + in 404 page when user clicks on go to homepage it redirects to homepage.

### DIFF
--- a/client/src/Components/Error.jsx
+++ b/client/src/Components/Error.jsx
@@ -38,7 +38,7 @@ export default function Error() {
               Sorry, we can't access that page without Login.
             </p>
             <Link
-              to="/login"
+              to="/"
               className="inline-flex text-white bg-primary-600 hover:bg-primary-800 focus:ring-4 focus:outline-none focus:ring-primary-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:focus:ring-primary-900 my-4"
             >
               Go to Homepage

--- a/client/src/Pages/HomePage.jsx
+++ b/client/src/Pages/HomePage.jsx
@@ -52,7 +52,7 @@ export default function Homepage() {
               their aspirations.
             </p>
             <Link
-              to="/Home"
+              to="/Login"
               class="inline-flex items-center justify-center px-5 py-3 mr-3 text-base font-medium text-center text-white rounded-lg bg-primary-700 hover:bg-primary-800 focus:ring-4 focus:ring-primary-300 dark:focus:ring-primary-900"
             >
               Get started


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

Currently when user clicks on get started it redirects to 404 page and there when clicked on go to homepage button that redirects to login page which is inappropriate behavior.

## Proposed changes

Changed the get started redirection to login page and in 404 page changed the go to homepage redirection to homepage.
issue bug #28 

## Checks

<!--
To help us review and merge this pull request quickly, please confirm the following
by replacing the [ ] in front of each bullet point below with [x]
-->

- [ x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.

<!-- We're looking forward to merging your contribution!! -->