### PR TITLE
fixed initial node position and image collision fixes #62

### DIFF
--- a/client/src/Pages/TimelineLearningPath.jsx
+++ b/client/src/Pages/TimelineLearningPath.jsx
@@ -117,7 +117,7 @@ const DataScienceTimeline = ({ initialTimelineData, subjectName }) => {
                   ))}
                 </div>
                 <img
-                  className="mx-auto -mt-36 md:-mt-36"
+                  className="mx-auto -mt-36 md:mt-36"
                   src="https://user-images.githubusercontent.com/54521023/116968861-ef21a000-acd2-11eb-95ac-a34b5b490265.png"
                 />
               </div>

--- a/client/src/Pages/TreeLearningPath.jsx
+++ b/client/src/Pages/TreeLearningPath.jsx
@@ -1,9 +1,9 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import axios from "axios";
 import Tree from "react-d3-tree";
 import RichText from "../Components/RichText";
 import LargeModal from "../Components/LargeModal";
-import {Triangle} from "react-loader-spinner"
+import { Triangle } from "react-loader-spinner";
 
 export default function LearningPath({ data }) {
   console.log(data);
@@ -15,7 +15,11 @@ export default function LearningPath({ data }) {
 
   if (!treeData) {
     // Show loading or some other UI while fetching the data
-    return <div className='w-full h-screen flex flex-row justify-center items-center'><Triangle height={'100'} width={'100'} color='#132043'/> </div>;
+    return (
+      <div className="w-full h-screen flex flex-row justify-center items-center">
+        <Triangle height={"100"} width={"100"} color="#132043" />{" "}
+      </div>
+    );
   }
 
   return (
@@ -31,7 +35,39 @@ function OrgChartTree({ treeData }) {
   };
   const [showModal, setShowModal] = useState(false);
   const nodeSize = { x: 900, y: 400 };
-  const foreignObjectProps = { width: nodeSize.x, height: "1500", x: 70 };
+  const treeRef = useRef();
+  const foreignObjectProps = {
+    width: nodeSize.x,
+    height: "1500",
+    x: 70,
+  };
+
+  const centerNode = (node) => {
+    const { width, height } = node.getBoundingClientRect();
+    const tree = treeRef.current;
+
+    const { x: initialX, y: initialY } = tree.props.translate;
+    const x = width / 2;
+    const y = height / 4;
+
+    const parentNode = document.getElementsByClassName(
+      `${tree.gInstanceRef}`
+    )[0];
+
+    const transform = parentNode.getAttribute("transform");
+
+    parentNode.removeAttribute("transform");
+    parentNode.setAttribute(
+      "transform",
+      `translate(${initialX + x}, ${initialY + y})`
+    );
+  };
+
+  useEffect(() => {
+    if (treeData) {
+      centerNode(document.getElementById("treeWrapper"));
+    }
+  }, []);
 
   return (
     <div
@@ -40,8 +76,9 @@ function OrgChartTree({ treeData }) {
       className="border-4 border-black"
     >
       <Tree
+        ref={treeRef}
         data={treeData}
-        initialDepth={0}
+        initialDepth={1}
         orientation="vertical"
         renderCustomNodeElement={(rd3tProps) => (
           <RenderForeignObjectNode


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior
fixes #62 
1) The initial node in the learning path was at postion [0, 0] i.e. top-left corner of the page.
2) The image in the timeline page was colliding with the timeline
3) there was only one initial node

## Proposed changes

1) fixed the position of initial node by centering it to the middle of the page using trnasform property and useEffect() hook.
![image](https://github.com/TechNodes2-0/ElectiveHub/assets/92782099/d36f1fb6-a2c9-4a20-ac7e-102f3a539c0f)
![image](https://github.com/TechNodes2-0/ElectiveHub/assets/92782099/16c5c708-b253-408a-9f84-5277f9e948c7)

2) fixed the margin of the colliding image
![image](https://github.com/TechNodes2-0/ElectiveHub/assets/92782099/1df3054c-c026-4fa4-8d04-a586a8e1840c)
![image](https://github.com/TechNodes2-0/ElectiveHub/assets/92782099/66445b63-b93d-494c-84a6-80a00488c93b)

3) set initial height of the tree to 1

## Checks

<!--
To help us review and merge this pull request quickly, please confirm the following
by replacing the [ ] in front of each bullet point below with [x]
-->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.

<!-- We're looking forward to merging your contribution!! -->