### PR TITLE
Updated TimelineLearningPath and TreeLearningPath

### DIFF
--- a/client/src/Pages/AdminPage/Admin.jsx
+++ b/client/src/Pages/AdminPage/Admin.jsx
@@ -93,7 +93,7 @@ export default function Admin() {
                 <a
                   class={
                     (activeTab === "dashboard" ? "bg-gray-900 " : "") +
-                    "flex items-center gap-x-3.5 py-2 px-2.5 text-sm text-slate-700 rounded-md hover:bg-gray-900 text-slate-400 dark:hover:text-slate-300"
+                    "flex items-center gap-x-3.5 py-2 px-2.5 text-sm rounded-md hover:bg-gray-900 text-slate-400 dark:hover:text-slate-300"
                   }
                   href="javascript:;"
                   onClick={handleTabClick.bind(this, "dashboard")}
@@ -106,7 +106,7 @@ export default function Admin() {
                 <a
                   class={
                     (activeTab === "Subject" ? "bg-gray-900 " : "") +
-                    "flex items-center gap-x-3.5 py-2 px-2.5 text-sm text-slate-700 rounded-md hover:bg-gray-900 text-slate-400 dark:hover:text-slate-300"
+                    "flex items-center gap-x-3.5 py-2 px-2.5 text-sm  rounded-md hover:bg-gray-900 text-slate-400 dark:hover:text-slate-300"
                   }
                   href="javascript:;"
                   onClick={handleTabClick.bind(this, "Subject")}
@@ -118,7 +118,7 @@ export default function Admin() {
                 <a
                   class={
                     (activeTab === "Student" ? "bg-gray-900 " : "") +
-                    "flex items-center gap-x-3.5 py-2 px-2.5 text-sm text-slate-700 rounded-md hover:bg-gray-900 text-slate-400 dark:hover:text-slate-300"
+                    "flex items-center gap-x-3.5 py-2 px-2.5 text-sm  rounded-md hover:bg-gray-900 text-slate-400 dark:hover:text-slate-300"
                   }
                   href="javascript:;"
                   onClick={handleTabClick.bind(this, "Student")}

--- a/client/src/Pages/TimelineLearningPath.jsx
+++ b/client/src/Pages/TimelineLearningPath.jsx
@@ -45,7 +45,7 @@ const DataScienceTimeline = ({ initialTimelineData, subjectName }) => {
             </div>
             <div className="ml-0 md:ml-12 lg:w-2/3 sticky">
               <div className="container mx-auto w-full h-full">
-                <div className="relative wrap overflow-hidden p-10 h-full">
+                <div className="relative wrap overflow-hidden p-5 h-full">
                   <div
                     className="border-2-2 border-blue-555 absolute h-full border"
                     style={{
@@ -80,7 +80,7 @@ const DataScienceTimeline = ({ initialTimelineData, subjectName }) => {
                         <div className="mb-3 text-base">Step {index + 1}:</div>
                         <h4 className="text-blue-500 mb-3 font-bold text-lg md:text-2xl">
                           {step.title}{" "}
-                          <span className="font-semibold text-md text-slate-600 ">
+                          <span className="font-semibold text-md text-slate-600 block">
                             {step.category}
                           </span>
                         </h4>
@@ -117,7 +117,7 @@ const DataScienceTimeline = ({ initialTimelineData, subjectName }) => {
                   ))}
                 </div>
                 <img
-                  className="mx-auto -mt-36 md:-mt-36"
+                  className="mx-auto -mt-36 md:mt-20"
                   src="https://user-images.githubusercontent.com/54521023/116968861-ef21a000-acd2-11eb-95ac-a34b5b490265.png"
                 />
               </div>

--- a/client/src/Pages/TreeLearningPath.jsx
+++ b/client/src/Pages/TreeLearningPath.jsx
@@ -1,12 +1,10 @@
 import React, { useState, useEffect } from "react";
-import axios from "axios";
 import Tree from "react-d3-tree";
 import RichText from "../Components/RichText";
 import LargeModal from "../Components/LargeModal";
-import {Triangle} from "react-loader-spinner"
+import { Triangle } from "react-loader-spinner"
 
 export default function LearningPath({ data }) {
-  console.log(data);
   useEffect(() => {
     setTreeData(data);
   }, [data]);
@@ -15,11 +13,11 @@ export default function LearningPath({ data }) {
 
   if (!treeData) {
     // Show loading or some other UI while fetching the data
-    return <div className='w-full h-screen flex flex-row justify-center items-center'><Triangle height={'100'} width={'100'} color='#132043'/> </div>;
+    return <div className='w-full h-screen flex flex-row justify-center items-center'><Triangle height={'100'} width={'100'} color='#132043' /> </div>;
   }
 
   return (
-    <div>
+    <div className="w-full border-2">
       <OrgChartTree treeData={treeData} />
     </div>
   );
@@ -37,11 +35,10 @@ function OrgChartTree({ treeData }) {
     <div
       id="treeWrapper"
       style={containerStyles}
-      className="border-4 border-black"
     >
       <Tree
         data={treeData}
-        initialDepth={0}
+        initialDepth={1}
         orientation="vertical"
         renderCustomNodeElement={(rd3tProps) => (
           <RenderForeignObjectNode
@@ -49,18 +46,46 @@ function OrgChartTree({ treeData }) {
             foreignObjectProps={foreignObjectProps}
             showModal={showModal}
             handleButtonClick={handleButtonClick}
-            onNodeClick={() => handleButtonClick()}
+            onNodeClick={handleButtonClick}
           />
         )}
+        translate={{
+          x: 300,
+          y: 50,
+        }}
         nodeSize={nodeSize}
-        // enableLegacyTransitions={true}
+        transitionDuration={5000}
+        zoomable={true}
+        draggable={true}
+        zoom={1}
+        styles={{
+          nodes: {
+            node: {
+              circle: {
+                fill: '#ffffff',
+              },
+              attributes: {
+                stroke: '#000',
+              },
+            },
+            leafNode: {
+              circle: {
+                fill: 'transparent',
+              },
+              attributes: {
+                stroke: '#000',
+              },
+            },
+          },
+        }}
+      // enableLegacyTransitions={true}
       />
     </div>
   );
 }
 
 const containerStyles = {
-  width: "100vw",
+  width: "full",
   height: "100vh",
 };
 
@@ -86,7 +111,7 @@ const RenderForeignObjectNode = ({
         x={foreignObjectProps.x}
       >
         {!showModal && (
-          <div className="max-w-sm p-6 border border-gray-200 rounded-lg shadow dark:bg-gray-800 dark:border-gray-700">
+          <div className="max-w-sm w-fit py-2 px-8 border border-gray-200 rounded-lg shadow dark:bg-gray-800 dark:border-gray-700">
             <a href="#">
               <h5 className="mb-2 text-2xl font-bold tracking-tight text-red-900 dark:text-white">
                 {nodeDatum?.name}


### PR DESCRIPTION
Updated TimelineLearningPath and TreeLearningPath 

<!-- Thank you for sending a pull request :heart: -->

## Current behavior

The current behavior of the learning path pages includes:

The central node of the learning path tree is initially positioned at the _top left of the screen._
Only one initial level is displayed on the learning path tree.
_Images on the Time learning path page collide_ with _timelines_ at the bottom.

## Proposed changes

Changes Made:

**_Fixes Issue_** #62 

Adjusted the positioning of the central node on the learning path tree.
Implemented logic to display two initial levels on the learning path tree.
Fixed the layout issue causing image collision with timelines on the Time learning path page.

**_TreeLearningPath_**

![fix1](https://github.com/TechNodes2-0/ElectiveHub/assets/124426004/1308ce59-1399-4c41-9179-7b6b6aaf639f)

**_TimelineLearningPath_**

![fix2](https://github.com/TechNodes2-0/ElectiveHub/assets/124426004/558a827f-9c1f-451e-842e-db99db27b41c)


## Checks

<!--
To help us review and merge this pull request quickly, please confirm the following
by replacing the [ ] in front of each bullet point below with [x]
-->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
