### PR TITLE
fixed[#79]: chat size wrapper resized 

### DIFF
--- a/client/src/alan.jsx
+++ b/client/src/alan.jsx
@@ -7,12 +7,19 @@ function AlanAIComponent() {
   useEffect(() => {
     // Load Alan AI script asynchronously when the component mounts on the client side
     
+    //extended additional design to fix the overflow of chatwrapper by fixing to 90% of the parent 
     const additionalStyles = `
     .alanBtn-root {
       right: 46px !important;
       bottom: 150px !important;
     }
-  `;
+    #alan-text-chat-wrapper{
+      height: 95%;
+      bottom: 0px;
+      position: fixed;
+    }
+  `
+  ;
 
   const styleTag = document.createElement('style');
   styleTag.innerHTML = additionalStyles;


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

The Chat pop-up is correctly positioned and resized.

## Changes made

- Resized the chat wrapper to be 95% of the view-port
- Changed position to fixed and bottom margin to 0px for bottom floating effect
On Regular Desktop-
![image](https://github.com/TechNodes2-0/ElectiveHub/assets/122856861/9a069453-e98f-4b36-ae5d-c8e4c8700bd4)
On smaller height-
![image](https://github.com/TechNodes2-0/ElectiveHub/assets/122856861/4810c8f3-986a-4ff4-b3bc-342394ad1206)


## Checks

<!--
To help us review and merge this pull request quickly, please confirm the following
by replacing the [ ] in front of each bullet point below with [x]
-->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.

<!-- We're looking forward to merging your contribution!! -->